### PR TITLE
Newer version of Python required

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ Enjoy.
 
 ## Requires
 
-- Python >= 3.4
+- Python >= 3.5
 - gitlab >= 7.0
 - redmine >= 1.3
 - curl


### PR DESCRIPTION
As discussed in issue #2, the minimal version required is now Python 3.5 (because of the use of `os.scandir()`)